### PR TITLE
Change simple from boolean to uint32.

### DIFF
--- a/src/yang/ietf-mup.yang
+++ b/src/yang/ietf-mup.yang
@@ -395,11 +395,14 @@ module ietf-mup {
           }
 
           leaf simple {
-            type boolean;
+            type uint32;
+            must ". < ../number";
             description
-              "Indicates that when MUP routes exceed number, routes
-               can still be added into the routing table, but the
-               system prompts alarms.
+              "Indicates the threshold value for number of MUP
+               routes that will be accepted. When MUP routes
+               exceed this number, routes can still be added
+               into the routing table, but the system prompts
+               alarms.
              
                However, after the total number of VPN routes and
                network public routes reaches the unicast route limit


### PR DESCRIPTION
Address issue #18.

The `simple` leaf was defined as a boolean to indicate that total '`number`' of routes had exceeded. However, it might be better to be able to set a value, i.e. threshold value, that is less than the number, so that if the threshold is crossed an alarm can be raised. That also aligns with the `percentage` configuration, which is a percentage of the total number of routes when an alarm should be raised.

